### PR TITLE
READMEにClaude CodeのCLI設定手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP Gemini Google Search
 
+[日本語](README_ja.md)
+
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that provides Google Search functionality using Gemini's built-in [Grounding with Google Search](https://ai.google.dev/gemini-api/docs/google-search) feature.
 
 This project is inspired by the GoogleSearch tool from [gemini-cli](https://github.com/google-gemini/gemini-cli/blob/9897a2b80a6f371363faf1345f406ea581b841db/docs/tools/web-search.md).
@@ -41,40 +43,53 @@ export GEMINI_MODEL="gemini-2.5-flash"  # Optional (default: gemini-2.5-flash)
 
 ### Claude Code Configuration
 
-Add the following to your Claude Code settings:
+You can set up this MCP server in Claude Code using the CLI:
 
 #### For Google AI Studio
-```json
-{
-  "mcpServers": {
-    "gemini-google-search": {
-      "command": "npx",
-      "args": ["mcp-gemini-google-search"],
-      "env": {
-        "GEMINI_API_KEY": "your-api-key-here",
-        "GEMINI_MODEL": "gemini-2.5-flash"
-      }
-    }
-  }
-}
+```bash
+# Add to user scope (available across all projects)
+claude mcp add gemini-google-search \
+  -s user \
+  -e GEMINI_API_KEY="your-api-key-here" \
+  -e GEMINI_MODEL="gemini-2.5-flash" \
+  -- npx mcp-gemini-google-search
+
+# Or add to project scope to share with your team
+claude mcp add gemini-google-search \
+  -s project \
+  -e GEMINI_API_KEY="your-api-key-here" \
+  -e GEMINI_MODEL="gemini-2.5-flash" \
+  -- npx mcp-gemini-google-search
 ```
 
 #### For Vertex AI
-```json
-{
-  "mcpServers": {
-    "gemini-google-search": {
-      "command": "npx",
-      "args": ["mcp-gemini-google-search"],
-      "env": {
-        "GEMINI_PROVIDER": "vertex",
-        "VERTEX_PROJECT_ID": "your-gcp-project-id",
-        "VERTEX_LOCATION": "us-central1",
-        "GEMINI_MODEL": "gemini-2.5-flash"
-      }
-    }
-  }
-}
+```bash
+# Add to user scope (available across all projects)
+claude mcp add gemini-google-search \
+  -s user \
+  -e GEMINI_PROVIDER="vertex" \
+  -e VERTEX_PROJECT_ID="your-gcp-project-id" \
+  -e VERTEX_LOCATION="us-central1" \
+  -e GEMINI_MODEL="gemini-2.5-flash" \
+  -- npx mcp-gemini-google-search
+
+# Or add to project scope to share with your team
+claude mcp add gemini-google-search \
+  -s project \
+  -e GEMINI_PROVIDER="vertex" \
+  -e VERTEX_PROJECT_ID="your-gcp-project-id" \
+  -e VERTEX_LOCATION="us-central1" \
+  -e GEMINI_MODEL="gemini-2.5-flash" \
+  -- npx mcp-gemini-google-search
+```
+
+#### Windows Users
+On Windows, wrap the npx command with `cmd /c`:
+
+```bash
+claude mcp add gemini-google-search \
+  -e GEMINI_API_KEY="your-api-key-here" \
+  -- cmd /c npx mcp-gemini-google-search
 ```
 
 ### Available Tools

--- a/README_ja.md
+++ b/README_ja.md
@@ -41,40 +41,53 @@ export GEMINI_MODEL="gemini-2.5-flash"  # オプション（デフォルト: gem
 
 ### Claude Code での設定
 
-Claude Code の設定に以下を追加：
+CLIを使用してMCPサーバーを設定できます：
 
 #### Google AI Studio を使用する場合
-```json
-{
-  "mcpServers": {
-    "gemini-google-search": {
-      "command": "npx",
-      "args": ["mcp-gemini-google-search"],
-      "env": {
-        "GEMINI_API_KEY": "your-api-key-here",
-        "GEMINI_MODEL": "gemini-2.5-flash"
-      }
-    }
-  }
-}
+```bash
+# userスコープに追加（全プロジェクトで利用可能）
+claude mcp add gemini-google-search \
+  -s user \
+  -e GEMINI_API_KEY="your-api-key-here" \
+  -e GEMINI_MODEL="gemini-2.5-flash" \
+  -- npx mcp-gemini-google-search
+
+# またはプロジェクトスコープに追加（チームで共有）
+claude mcp add gemini-google-search \
+  -s project \
+  -e GEMINI_API_KEY="your-api-key-here" \
+  -e GEMINI_MODEL="gemini-2.5-flash" \
+  -- npx mcp-gemini-google-search
 ```
 
 #### Vertex AI を使用する場合
-```json
-{
-  "mcpServers": {
-    "gemini-google-search": {
-      "command": "npx",
-      "args": ["mcp-gemini-google-search"],
-      "env": {
-        "GEMINI_PROVIDER": "vertex",
-        "VERTEX_PROJECT_ID": "your-gcp-project-id",
-        "VERTEX_LOCATION": "us-central1",
-        "GEMINI_MODEL": "gemini-2.5-flash"
-      }
-    }
-  }
-}
+```bash
+# userスコープに追加（全プロジェクトで利用可能）
+claude mcp add gemini-google-search \
+  -s user \
+  -e GEMINI_PROVIDER="vertex" \
+  -e VERTEX_PROJECT_ID="your-gcp-project-id" \
+  -e VERTEX_LOCATION="us-central1" \
+  -e GEMINI_MODEL="gemini-2.5-flash" \
+  -- npx mcp-gemini-google-search
+
+# またはプロジェクトスコープに追加（チームで共有）
+claude mcp add gemini-google-search \
+  -s project \
+  -e GEMINI_PROVIDER="vertex" \
+  -e VERTEX_PROJECT_ID="your-gcp-project-id" \
+  -e VERTEX_LOCATION="us-central1" \
+  -e GEMINI_MODEL="gemini-2.5-flash" \
+  -- npx mcp-gemini-google-search
+```
+
+#### Windows ユーザー
+Windowsでは、npxコマンドを`cmd /c`でラップしてください：
+
+```bash
+claude mcp add gemini-google-search \
+  -e GEMINI_API_KEY="your-api-key-here" \
+  -- cmd /c npx mcp-gemini-google-search
 ```
 
 ### 利用可能なツール
@@ -176,4 +189,4 @@ npm run inspect
 
 ## ライセンス
 
-MIT
+Apache License 2.0


### PR DESCRIPTION
## 概要
- JSON設定ファイルによる手動設定から `claude mcp add` CLI コマンドを使用する方法に変更
- userスコープ（全プロジェクトで利用可能）とprojectスコープ（チーム共有）の両方の例を追加
- Windows用の特別な設定手順も追加
- メインREADMEに日本語版READMEへのリンクを追加
- 日本語版READMEのライセンス表記をApache License 2.0に修正

## テストプラン
- [ ] CLI設定手順が正確であることを確認
- [ ] 日本語版READMEのリンクが正しく動作することを確認
- [ ] 両方のREADMEで一貫した内容になっていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)